### PR TITLE
Update egg-windrose.json

### DIFF
--- a/windrose/egg-windrose.json
+++ b/windrose/egg-windrose.json
@@ -18,7 +18,7 @@
     "startup": "wine \/home\/container\/R5\/Binaries\/Win64\/WindroseServer-Win64-Shipping.exe -log & WINDROSE_PID=$!; tail -c0 -F \/home\/container\/R5\/Saved\/Logs\/R5.log --pid=$WINDROSE_PID",
     "config": {
         "files": "{\r\n    \"R5\/ServerDescription.json\": {\r\n        \"parser\": \"json\",\r\n        \"find\": {\r\n            \"ServerDescription_Persistent.ServerName\": \"{{server.build.env.SERVER_NAME}}\",\r\n            \"ServerDescription_Persistent.InviteCode\": \"{{server.build.env.INVITE_CODE}}\",\r\n            \"ServerDescription_Persistent.IsPasswordProtected\": \"{{server.build.env.SERVER_PASSWORD_PROTECTED}}\",\r\n            \"ServerDescription_Persistent.Password\": \"{{server.build.env.SERVER_PASSWORD}}\",\r\n            \"ServerDescription_Persistent.MaxPlayerCount\": \"{{server.build.env.MAX_PLAYERS}}\",\r\n            \"ServerDescription_Persistent.P2pProxyAddress\": \"{{server.build.env.P2P_PROXY}}\",\r\n            \"ServerDescription_Persistent.UseDirectConnection\": \"{{server.build.env.USE_DIRECT_CONNECTION}}\",\r\n            \"ServerDescription_Persistent.DirectConnectionServerAddress\": \"{{server.build.default.ip}}\",\r\n            \"ServerDescription_Persistent.DirectConnectionServerPort\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
-        "startup": "{\r\n    \"done\": \"Bringing up level for play took\"\r\n}",
+        "startup": "{\r\n    \"done\": \"UEngine::LoadMap Load map complete\"\r\n}",
         "logs": "{}",
         "stop": "^C"
     },
@@ -42,12 +42,12 @@
         },
         {
             "name": "Use Direct Connection",
-            "description": "Enable direct connection instead of invite codes, when set to 1 (enabled) it will disable the use of the Invite Code.",
+            "description": "Enable or disable Direct IP connection mode for the server. Set to true to allow players to connect using the server IP and port instead of an invite code. When enabled, invite codes are not used.",
             "env_variable": "USE_DIRECT_CONNECTION",
-            "default_value": "0",
+            "default_value": "false",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|boolean",
+            "rules": "required|string|in:true,false",
             "field_type": "text"
         },
         {
@@ -62,22 +62,22 @@
         },
         {
             "name": "Max players",
-            "description": "Maximum allowed players",
+            "description": "The maximum number of players allowed on the server at the same time. Up to 4 players is recommended for smoother performance.",
             "env_variable": "MAX_PLAYERS",
-            "default_value": "8",
+            "default_value": "4",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|string|max:20",
+            "rules": "required|integer|min:1|max:32",
             "field_type": "text"
         },
         {
             "name": "Auto Update",
             "description": "Decide if you want to update your server",
             "env_variable": "AUTO_UPDATE",
-            "default_value": "1",
+            "default_value": "true",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|boolean",
+            "rules": "required|string|in:true,false",
             "field_type": "text"
         },
         {
@@ -94,10 +94,10 @@
             "name": "Password Protected",
             "description": "Off by default, enable this when using a server password",
             "env_variable": "SERVER_PASSWORD_PROTECTED",
-            "default_value": "0",
+            "default_value": "true",
             "user_viewable": true,
             "user_editable": true,
-            "rules": "required|boolean",
+            "rules": "required|string|in:true,false",
             "field_type": "text"
         },
         {
@@ -111,7 +111,7 @@
             "field_type": "text"
         },
         {
-            "name": "App id",
+            "name": "Steam App id",
             "description": "The ID corresponding to the game to download.",
             "env_variable": "SRCDS_APPID",
             "default_value": "4129620",

--- a/windrose/egg-windrose.json
+++ b/windrose/egg-windrose.json
@@ -94,7 +94,7 @@
             "name": "Password Protected",
             "description": "Off by default, enable this when using a server password",
             "env_variable": "SERVER_PASSWORD_PROTECTED",
-            "default_value": "true",
+            "default_value": "false",
             "user_viewable": true,
             "user_editable": true,
             "rules": "required|string|in:true,false",


### PR DESCRIPTION
# Description
This PR fixes several Windrose-specific compatibility issues in the egg configuration.

Changes:
- update the startup done trigger to use `UEngine::LoadMap Load map complete`
- change Windrose boolean-style config values from `0/1` handling to explicit `true/false`
- validate `MAX_PLAYERS` as an integer instead of a generic string
- lower the default player count from 8 to 4 to better reflect recommended performance for smaller servers

Why:
Windrose reads values from `R5/ServerDescription.json`, and several fields are more reliable when passed in the format the game expects rather than generic panel-style boolean handling. This PR keeps the egg structure intact while correcting value formats and validation for the game’s config.

The current egg uses panel boolean-style `0/1` defaults and validation for settings that are written directly into `ServerDescription.json`. For Windrose, explicit `true/false` values are more reliable for these config fields and avoid values being ignored or mishandled by the game.

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [X] Have you followed the guidelines in our [Contributing document](https://github.com/Ptero-Eggs/.github/blob/main/profile/CONTRIBUTING.md)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [X] Have you tested and reviewed your changes with confidence that everything works?
* [X] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [X] You verify that the start command applied does not use a shell script
  * [ ] If some script is needed then it is part of a current yolk or a PR to add one
* [X] The egg was exported from the panel